### PR TITLE
Update ci config (xdebug now included by default)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ jobs:
       - checkout
 
       - run:
-          name: Add XDebug
-          command: pecl install xdebug-2.5.0 && docker-php-ext-enable xdebug
-
-      - run:
           name: Install Composer Dependencies
           command: composer install --no-progress --no-suggest
 


### PR DESCRIPTION
I made a PR into Laratools/CI to include XDebug by default, so we shouldn't have to pull it in ourselves during testing. 